### PR TITLE
Add a way to customize the load command to run loadHTML or pass addition...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,16 @@ php:
   - 5.5
   - 5.6
   - hhvm
- 
+
 matrix:
     allow_failures:
         - php: hhvm
+
+before_install:
+  # need to update libxml to 2.7.8 to be able to run tests using the
+  # LIBXML_HTML_NODEFDTD and LIBXML_HTML_NOIMPLIED libxml constant
+  - sudo apt-get update
+  - sudo apt-get -o DPkg::Options::="--force-confold" -y upgrade
 
 before_script:
   - composer self-update
@@ -17,7 +23,7 @@ before_script:
 script:
   - ./vendor/bin/phpunit -c ./tests
   - ./vendor/bin/phpcs --standard=PSR2 --ignore=tests/Bootstrap.php library tests
-  
+
 notifications:
   irc: "irc.freenode.org#zftalk.dev"
   email: false

--- a/tests/ZendXmlTest/SecurityTest.php
+++ b/tests/ZendXmlTest/SecurityTest.php
@@ -79,6 +79,14 @@ XML;
     {
         // loadHtml accepts constants in php >= 5.4
         // http://php.net/manual/de/domdocument.loadhtml.php
+        // LIBXML_HTML_NODEFDTD and LIBXML_HTML_NOIMPLIED require libxml 2.7.8+
+        // http://php.net/manual/de/libxml.constants.php
+        if (version_compare(LIBXML_DOTTED_VERSION, '2.7.8', '<')) {
+            $this->markTestSkipped(
+                'libxml 2.7.8+ required but found ' . LIBXML_DOTTED_VERSION
+            );
+        }
+
         $dom = new DOMDocument('1.0');
         $html = <<<HTML
 <p>a simple test</p>

--- a/tests/ZendXmlTest/SecurityTest.php
+++ b/tests/ZendXmlTest/SecurityTest.php
@@ -72,6 +72,23 @@ XML;
         $this->assertEquals($node->nodeValue, 'test');
     }
 
+    /**
+     * @requires PHP 5.4
+     */
+    public function testScanDomHTML()
+    {
+        // loadHtml accepts constants in php >= 5.4
+        // http://php.net/manual/de/domdocument.loadhtml.php
+        $dom = new DOMDocument('1.0');
+        $html = <<<HTML
+<p>a simple test</p>
+HTML;
+        $constants = LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED;
+        $result = XmlSecurity::scanHtml($html, $dom, $constants);
+        $this->assertTrue($result instanceof DOMDocument);
+        $this->assertEquals($html, trim($result->saveHtml()));
+    }
+
     public function testScanInvalidXml()
     {
         $xml = <<<XML


### PR DESCRIPTION
Add a way to customize the load command to run `loadHTML` or pass additional parameters to `loadXML`

Example:

``` php
$xmlDom = XmlSecurity::scan($xml, $dom, LIBXML_COMPACT);
$htmlDom = XmlSecurity::scanHtml($html, $dom, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
```

@ezimuel 
