### PR TITLE
remove php 5.5 check for isVulnerable as the composer.json require php ^5.6 as minimal

### DIFF
--- a/src/Security.php
+++ b/src/Security.php
@@ -128,7 +128,7 @@ class Security
      * (vs libxml checks) should be made, due to threading issues in libxml;
      * under php-fpm, threading becomes a concern.
      *
-     * However, PHP versions 5.5.22+ and 5.6.6+ contain a patch to the
+     * However, PHP versions 5.6.6+ contain a patch to the
      * libxml support in PHP that makes the libxml checks viable; in such
      * versions, this method will return false to enforce those checks, which
      * are more strict and accurate than the heuristic checks.
@@ -138,8 +138,7 @@ class Security
     public static function isPhpFpm()
     {
         $isVulnerableVersion = (
-            version_compare(PHP_VERSION, '5.5.22', 'lt')
-            || (
+            (
                 version_compare(PHP_VERSION, '5.6', 'gte')
                 && version_compare(PHP_VERSION, '5.6.6', 'lt')
             )


### PR DESCRIPTION
- [x] Is this related to quality assurance?
