### PR TITLE
Fix the version_compare check for isPhpFpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#17](https://github.com/zendframework/ZendXml/pull/13) properly enables heuristic security checks for PHP 5.6.0-5.6.5 when PHP is running as PHP-FPM.
 
 ## 1.1.0 - 2018-04-30
 

--- a/src/Security.php
+++ b/src/Security.php
@@ -140,7 +140,7 @@ class Security
         $isVulnerableVersion = (
             version_compare(PHP_VERSION, '5.5.22', 'lt')
             || (
-                version_compare(PHP_VERSION, '5.6', 'gte')
+                version_compare(PHP_VERSION, '5.6', 'ge')
                 && version_compare(PHP_VERSION, '5.6.6', 'lt')
             )
         );


### PR DESCRIPTION
See http://php.net/manual/en/function.version-compare.php#refsect1-function.version-compare-parameters

`gte` is a typo, this should be `ge`

